### PR TITLE
Fixed bug where you had to press search twice to display results

### DIFF
--- a/frontend/app/src/androidTest/java/com/example/foodo/ManageFoodoListTest.java
+++ b/frontend/app/src/androidTest/java/com/example/foodo/ManageFoodoListTest.java
@@ -361,8 +361,6 @@ public class ManageFoodoListTest {
         searchAutoComplete.perform(replaceText("Tim Hortons"), closeSoftKeyboard());
 
         searchAutoComplete.perform(pressImeActionButton());
-        Thread.sleep(100);
-        searchAutoComplete.perform(pressImeActionButton());
 
         Thread.sleep(3000);
 

--- a/frontend/app/src/androidTest/java/com/example/foodo/ManageReviewsTest.java
+++ b/frontend/app/src/androidTest/java/com/example/foodo/ManageReviewsTest.java
@@ -145,9 +145,6 @@ public class ManageReviewsTest {
 
 
         searchAutoComplete.perform(pressImeActionButton());
-        // Have to click twice Search Button twice on first search: Peer group pointed this out. Must fix!
-        Thread.sleep(1000);
-        searchAutoComplete.perform(pressImeActionButton());
 
         Thread.sleep(1000);
 

--- a/frontend/app/src/androidTest/java/com/example/foodo/SearchForRestaurantInformationTest.java
+++ b/frontend/app/src/androidTest/java/com/example/foodo/SearchForRestaurantInformationTest.java
@@ -160,8 +160,6 @@ public class SearchForRestaurantInformationTest {
 
         Log.d(TAG, "Click Search Button");
 
-//        Thread.sleep(100);
-
         searchAutoComplete.perform(pressImeActionButton());
 
         Thread.sleep(2000);

--- a/frontend/app/src/androidTest/java/com/example/foodo/SearchForRestaurantInformationTest.java
+++ b/frontend/app/src/androidTest/java/com/example/foodo/SearchForRestaurantInformationTest.java
@@ -160,12 +160,8 @@ public class SearchForRestaurantInformationTest {
 
         Log.d(TAG, "Click Search Button");
 
-        searchAutoComplete.perform(pressImeActionButton());
+//        Thread.sleep(100);
 
-        Thread.sleep(100);
-
-        // Have to click twice Search Button twice on first search: Peer group pointed this out. Must fix!
-        // Set a small delay to ensure location is available by this point
         searchAutoComplete.perform(pressImeActionButton());
 
         Thread.sleep(2000);

--- a/frontend/app/src/main/java/com/example/foodo/MainActivity.java
+++ b/frontend/app/src/main/java/com/example/foodo/MainActivity.java
@@ -58,6 +58,7 @@ public class MainActivity extends AppCompatActivity {
     private Intent searchResultIntent;
     private Button loginButton;
     private TextView loginText;
+    private LocationManager locationManager;
     private Double lat;
     private Double lng;
     private final LocationListener locationListener = new LocationListener() {
@@ -74,6 +75,7 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
         mapsIntent = new Intent(MainActivity.this, MapActivity.class);
         searchResultIntent = new Intent(MainActivity.this, SearchResultActivity.class);
         loginButton = findViewById(R.id.login_button);
@@ -117,15 +119,38 @@ public class MainActivity extends AppCompatActivity {
         });
 
         SearchView restaurantSearch = findViewById(R.id.restaurant_search);
+
+        restaurantSearch.setOnSearchClickListener(new View.OnClickListener() {
+            @Override
+            @SuppressLint("MissingPermission")
+            public void onClick(View v) {
+                if (ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                    Log.d(TAG, "Permission was not granted, requesting permissions now");
+                    ActivityCompat.requestPermissions(MainActivity.this, new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION}, 1);
+                }else {
+                    locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 100, 0, locationListener);
+                    Log.d(TAG, "Permissions set!");
+                }
+            }
+        });
+
         restaurantSearch.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String query) {
-                Log.d(TAG, "submit");
-                return searchRestaurant(query);
+                if (ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                    Toast.makeText(getApplicationContext(), "Location permissions are needed in order to search!", Toast.LENGTH_LONG).show();
+                    return false;
+                }else {
+                    return searchRestaurant(query);
+                }
             }
 
             @Override
+            @SuppressLint("MissingPermission")
             public boolean onQueryTextChange(String newText) {
+                if (ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED || ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                    locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 100, 0, locationListener);
+                }
                 return false;
             }
         });
@@ -182,25 +207,10 @@ public class MainActivity extends AppCompatActivity {
         hideLoginPrompts();
     }
 
-    @SuppressLint("MissingPermission")
-    private boolean searchRestaurant(String query) {
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-            Log.d(TAG, "Permission was not granted, requesting permissions now");
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION}, 1);
-            return false;
-        }
 
-        LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
-        locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 100, 0, locationListener);
-
+    private boolean searchRestaurant(String query){
         HashMap<String, String> queryParameters = new HashMap<>();
         queryParameters.put("query", query);
-
-        if (lat == null || lng == null) {
-            Toast.makeText(this, "Unable to get location, please try again", Toast.LENGTH_LONG);
-            Log.d(TAG, "unable to get location");
-            return false;
-        }
 
         queryParameters.put("lat", String.valueOf(lat));
         queryParameters.put("lng", String.valueOf(lng));
@@ -292,6 +302,5 @@ public class MainActivity extends AppCompatActivity {
     public CountingIdlingResource getSearchQueryCountingIdlingResource() {
         return searchQueryCountingIdlingResource;
     }
-
 
 }


### PR DESCRIPTION
The Problem: Previously, we would ask for location permissions in the searchRestaurant() function, right after the user submits the query. If the user allowed this, the user would have to press submit again for the LocationListener to begin periodically pulling location data. The problem was that it wasn't pulling the location fast enough, so lat/lng would be null and the searchRestaurant function would return. By the next submit, lat/lng would be populated so the search would fire. TL:DR Our search is firing before we have location data.

The Fix: It's a little hacky, but essentially I ask the user for permission upon click of the search button instead of upon submitting. I then register the LocationListener in the onQueryTextChange() function so that upon any input into the search bar, the LocationListener would be immediately registered and have ample time to pull location data as the user is typing in their query. By the time the user submits, lat/lng should be registered and the search should fire successfully. I've tried it with the tests a couple of times and it seems to work well too.

I also realized that you have to call .show() on Toast texts... no wonder they weren't showing up before 💀. I added a message on query submit to inform the user that location permissions must be allowed if they search without giving permissions.

Closes #156 